### PR TITLE
Handle edge cases when using blocking queries

### DIFF
--- a/lib/tesla/middleware/consul_watch.ex
+++ b/lib/tesla/middleware/consul_watch.ex
@@ -50,11 +50,11 @@ defmodule Tesla.Middleware.ConsulWatch do
   end
 
   defp load_index(%{method: :get, url: url} = env, opts) do
-    case :ets.lookup(@index_table, url) do
-      [] ->
+    case current_index(url) do
+      nil ->
         env
 
-      [{_, index}] ->
+      index ->
         query =
           case Keyword.get(opts, :wait) do
             nil -> []
@@ -68,6 +68,13 @@ defmodule Tesla.Middleware.ConsulWatch do
   end
 
   defp load_index(env, _opts), do: env
+
+  defp current_index(url) do
+    case :ets.lookup(@index_table, url) do
+      [] -> nil
+      [{_, index}] -> index
+    end
+  end
 
   def to_gotime(duration) do
     ms =
@@ -103,16 +110,39 @@ defmodule Tesla.Middleware.ConsulWatch do
   end
 
   def store_index({:ok, %{url: url} = env}) do
-    case Tesla.get_header(env, @header_x_consul_index) do
-      nil ->
-        :ets.delete(@index_table, url)
+    index =
+      with [index | _] <- Tesla.get_headers(env, @header_x_consul_index),
+           {index, _} <- Integer.parse(index) do
+        index
+      else
+        _ -> nil
+      end
 
-      index ->
-        :ets.insert(@index_table, {url, index})
-    end
+    handle_new_index(url, index)
 
     {:ok, env}
   end
 
   def store_index({:error, reason}), do: {:error, reason}
+
+  defp handle_new_index(url, nil) do
+    :ets.delete(@index_table, url)
+  end
+
+  defp handle_new_index(url, new_index) do
+    current_index = current_index(url)
+
+    cond do
+      is_nil(current_index) ->
+        :ets.insert(@index_table, {url, new_index})
+
+      new_index < current_index || new_index < 1 ->
+        # reset index when it has moved backwards or is not greater than 0
+        # see: https://www.consul.io/api-docs/features/blocking#implementation-details
+        :ets.delete(@index_table, url)
+
+      true ->
+        :ets.insert(@index_table, {url, new_index})
+    end
+  end
 end

--- a/test/tesla/middleware/consul_watch_test.exs
+++ b/test/tesla/middleware/consul_watch_test.exs
@@ -64,7 +64,7 @@ defmodule Tesla.Middleware.ConsulWatchTest do
     {:ok, %{query: query}} = Tesla.get(conn(), "/v1/kv/#{@key}")
     refute Keyword.has_key?(query, :index)
 
-    # next request that returns index of 0
+    # next request that returns index of 50
     {:ok, env} = Tesla.get(conn(), "/v1/kv/#{@key}")
     assert Tesla.get_header(env, "x-consul-index") == "50"
 

--- a/test/tesla/middleware/consul_watch_test.exs
+++ b/test/tesla/middleware/consul_watch_test.exs
@@ -1,0 +1,117 @@
+defmodule Tesla.Middleware.ConsulWatchTest do
+  use ExUnit.Case
+  import Tesla.Mock
+
+  alias Tesla.Middleware.ConsulWatch
+
+  @base_url "http://consul"
+  @key "foo"
+
+  setup do
+    :ok = ConsulWatch.reset(%{url: "#{@base_url}/v1/kv/#{@key}"})
+  end
+
+  test "doesn't specify index on initial fetch" do
+    mock(fn env -> {:ok, response(env, "100")} end)
+
+    {:ok, %{query: query}} = Tesla.get(conn(), "/v1/kv/#{@key}")
+
+    refute Keyword.has_key?(query, :index)
+  end
+
+  test "specifies index on subsequent requests" do
+    mock(fn env -> {:ok, response(env, "100")} end)
+
+    # initial fetch
+    Tesla.get(conn(), "/v1/kv/#{@key}")
+
+    # subsequent request
+    {:ok, %{query: query}} = Tesla.get(conn(), "/v1/kv/#{@key}")
+
+    assert query[:index] == 100
+  end
+
+  test "resets index when consul responds with index that is not greater than zero" do
+    mock(fn %{query: query} = env ->
+      case Keyword.get(query, :index) do
+        nil -> {:ok, response(env, "100")}
+        100 -> {:ok, response(env, "0")}
+      end
+    end)
+
+    # initial fetch
+    {:ok, %{query: query}} = Tesla.get(conn(), "/v1/kv/#{@key}")
+    refute Keyword.has_key?(query, :index)
+
+    # next request that returns index of 0
+    {:ok, env} = Tesla.get(conn(), "/v1/kv/#{@key}")
+    assert Tesla.get_header(env, "x-consul-index") == "0"
+
+    # subsequent request
+    {:ok, %{query: query}} = Tesla.get(conn(), "/v1/kv/#{@key}")
+    refute Keyword.has_key?(query, :index)
+  end
+
+  test "resets index when consul responds with index that goes backwards" do
+    mock(fn %{query: query} = env ->
+      case Keyword.get(query, :index) do
+        nil -> {:ok, response(env, "100")}
+        100 -> {:ok, response(env, "50")}
+      end
+    end)
+
+    # initial fetch
+    {:ok, %{query: query}} = Tesla.get(conn(), "/v1/kv/#{@key}")
+    refute Keyword.has_key?(query, :index)
+
+    # next request that returns index of 0
+    {:ok, env} = Tesla.get(conn(), "/v1/kv/#{@key}")
+    assert Tesla.get_header(env, "x-consul-index") == "50"
+
+    # subsequent request
+    {:ok, %{query: query}} = Tesla.get(conn(), "/v1/kv/#{@key}")
+    refute Keyword.has_key?(query, :index)
+  end
+
+  test "doesn't wait on initial fetch" do
+    mock(fn env -> {:ok, response(env, "100")} end)
+
+    {:ok, %{query: query}} =
+      conn(wait: 123_456)
+      |> Tesla.get("/v1/kv/#{@key}")
+
+    refute Keyword.has_key?(query, :wait)
+  end
+
+  test "waits on subsequent requests" do
+    mock(fn env -> {:ok, response(env, "100")} end)
+
+    conn(wait: 123_456) |> Tesla.get("/v1/kv/#{@key}")
+
+    {:ok, %{query: query}} =
+      conn(wait: 123_456)
+      |> Tesla.get("/v1/kv/#{@key}")
+
+    assert query[:wait] == "2m3.456s"
+  end
+
+  defp conn(opts \\ []) do
+    opts = Keyword.put_new(opts, :wait, 0)
+    Consul.Connection.new(@base_url, [adapter: Tesla.Mock] ++ opts)
+  end
+
+  defp response(env, index) do
+    body = %{
+      "CreateIndex" => 1,
+      "Flags" => 0,
+      "Key" => @key,
+      "LockIndex" => 0,
+      "ModifyIndex" => index,
+      "Value" => "bar"
+    }
+
+    headers = [{"x-consul-index", index}]
+
+    %{env | status: 200, body: body, headers: headers}
+  end
+end


### PR DESCRIPTION
There are some possible edge cases that should be handled when using blocking queries with consul according to [official docs](https://www.consul.io/api-docs/features/blocking#implementation-details).

In short, index should be reset if:

* consul returns a new index with a lower value than the previous one
* consul returns a new index with a value not greater than zero

This PR adds handling for these cases as well as some tests for `ConsulWatch` middleware.
