### PR TITLE
Refactor and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For simple polling requests, just create a Consul connection and pass it to a
 
 ```elixir
 connection = Consul.Connection.new("http://consul:8500")
-Consul.Api.Health.list_nodes(connection, "my_service", passing: true)
+Consul.Api.V1.Health.list_nodes(connection, "my_service", passing: true)
 ```
 
 ### Blocking queries
@@ -56,7 +56,7 @@ In order to make blocking queries, use the option `:wait`:
 
 ```elixir
 connection = Consul.Connection.new("http://consul:8500", wait: 60_000)
-Consul.Api.Health.list_nodes(connection, "my_service")
+Consul.Api.V1.Health.list_nodes(connection, "my_service")
 ```
 
 In this case, the first execution will return immediately, while the next ones
@@ -69,7 +69,7 @@ configured with `wait`. It can be done by specifying `index: nil` option in the
 request.
 
 ```elixir
-Consul.Api.Health.list_nodes(connection, "my_service", index: nil)
+Consul.Api.V1.Health.list_nodes(connection, "my_service", index: nil)
 ```
 
 ## Read YAML values from Consul KV

--- a/README.md
+++ b/README.md
@@ -56,13 +56,21 @@ In order to make blocking queries, use the option `:wait`:
 
 ```elixir
 connection = Consul.Connection.new("http://consul:8500", wait: 60_000)
-Consul.Api.Health.list_nodes(connection, "my_service", passing: true)
+Consul.Api.Health.list_nodes(connection, "my_service")
 ```
 
 In this case, the first execution will return immediately, while the next ones
 will wait up to 60 seconds to finalize. The time passed in the `:wait` argument
 is in milliseconds. Alternatively `wait: true` can be passed to use Consul's
 default value for that parameter (5 minutes).
+
+Sometimes you may need to make a non-blocking query using a client that was
+configured with `wait`. It can be done by specifying `index: nil` option in the
+request.
+
+```elixir
+Consul.Api.Health.list_nodes(connection, "my_service", index: nil)
+```
 
 ## Read YAML values from Consul KV
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ connection = Consul.Connection.new("http://consul:8500")
 Consul.Api.Health.list_nodes(connection, "my_service", passing: true)
 ```
 
+### Blocking queries
+
+This feature is supported only by selected endpoints. Check
+[Consul documentation](https://developer.hashicorp.com/consul/api-docs/features/blocking)
+for more information.
+
 In order to make blocking queries, use the option `:wait`:
 
 ```elixir
@@ -55,7 +61,8 @@ Consul.Api.Health.list_nodes(connection, "my_service", passing: true)
 
 In this case, the first execution will return immediately, while the next ones
 will wait up to 60 seconds to finalize. The time passed in the `:wait` argument
-is in milliseconds.
+is in milliseconds. Alternatively `wait: true` can be passed to use Consul's
+default value for that parameter (5 minutes).
 
 ## Read YAML values from Consul KV
 

--- a/lib/consul/application.ex
+++ b/lib/consul/application.ex
@@ -4,7 +4,7 @@ defmodule Consul.Application do
   use Application
 
   def start(_type, _args) do
-    children = [Tesla.Middleware.ConsulWatch]
+    children = [Consul.IndexStore]
     Supervisor.start_link(children, strategy: :one_for_one)
   end
 end

--- a/lib/consul/connection.ex
+++ b/lib/consul/connection.ex
@@ -35,6 +35,27 @@ defmodule Consul.Connection do
 
   @doc """
   Builds a Tesla client.
+
+  ## Options
+
+    * `adapter` - specify custom Tesla adapter, if not set will use Tesla's
+      default one
+    * `retry` - options for `Tesla.Middleware.Retry` middleware
+    * `timeout` - when given, will include `Tesla.Middleware.Timeout`
+      middleware configured with given value
+    * `token` - when given, will include `x-consul-token` header with given
+      value in the requests
+    * `wait` - when given, will include `Tesla.Middleware.ConsulWatch`
+      middleware configured with given value in milliseconds
+
+  When using `wait` option, make sure its value is larger than the timeout
+  used by the underlying adapter (specified in options or default one).
+  Otherwise, the request may be timing out before wait period passes.
+
+  Note that using `timeout` option is not always sufficient to achieve this
+  as some adapters (e.g. `Tesla.Adapter.Finch`) are not compatible with
+  `Tesla.Middleware.Timeout` middleware that is used when `timeout` option
+  is specified.
   """
   def new(base_url, opts \\ []) do
     middleware = [

--- a/lib/consul/index_store.ex
+++ b/lib/consul/index_store.ex
@@ -1,0 +1,32 @@
+defmodule Consul.IndexStore do
+  @moduledoc """
+  This module keeps track of index values for consul blocking queries.
+  """
+
+  use GenServer
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def get_index(url) do
+    case :ets.lookup(__MODULE__, url) do
+      [{_, value}] -> value
+      _ -> nil
+    end
+  end
+
+  def store_index(url, value) do
+    :ets.insert(__MODULE__, {url, value})
+  end
+
+  def reset_index(url) do
+    :ets.delete(__MODULE__, url)
+  end
+
+  @impl GenServer
+  def init(_) do
+    __MODULE__ = :ets.new(__MODULE__, [:named_table, :public])
+    {:ok, nil}
+  end
+end

--- a/lib/tesla/middleware/consul_watch.ex
+++ b/lib/tesla/middleware/consul_watch.ex
@@ -95,11 +95,11 @@ defmodule Tesla.Middleware.ConsulWatch do
     end
   end
 
-  defp format_wait(nil), do: nil
-  defp format_wait(true), do: nil
   defp format_wait(wait) when is_binary(wait), do: wait
 
-  defp format_wait(duration) do
+  defp format_wait(duration) when is_number(duration) do
+    duration = trunc(duration)
+
     ms =
       case rem(duration, 1_000) do
         0 ->
@@ -131,4 +131,6 @@ defmodule Tesla.Middleware.ConsulWatch do
       h -> "#{h}h#{m}"
     end
   end
+
+  defp format_wait(_), do: nil
 end

--- a/lib/tesla/middleware/consul_watch.ex
+++ b/lib/tesla/middleware/consul_watch.ex
@@ -34,13 +34,16 @@ defmodule Tesla.Middleware.ConsulWatch do
   end
 
   defp maybe_set_index(%{method: :get, query: query} = env, url) do
-    case IndexStore.get_index(url) do
-      nil ->
-        env
+    index =
+      case Keyword.fetch(query, :index) do
+        {:ok, index} ->
+          index
 
-      index ->
-        %{env | query: Keyword.put(query, :index, index)}
-    end
+        _ ->
+          IndexStore.get_index(url)
+      end
+
+    %{env | query: Keyword.put(query, :index, index)}
   end
 
   defp maybe_set_wait(%{query: query} = env, wait) do

--- a/lib/tesla/middleware/consul_watch.ex
+++ b/lib/tesla/middleware/consul_watch.ex
@@ -93,6 +93,7 @@ defmodule Tesla.Middleware.ConsulWatch do
   end
 
   defp format_wait(nil), do: nil
+  defp format_wait(true), do: nil
   defp format_wait(wait) when is_binary(wait), do: wait
 
   defp format_wait(duration) do

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,8 @@ defmodule Consul.MixProject do
       deps: deps(),
       package: package(),
       source_url: "https://github.com/team-telnyx/consulex",
-      description: description()
+      description: description(),
+      aliases: aliases()
     ]
   end
 
@@ -45,6 +46,12 @@ defmodule Consul.MixProject do
       licenses: ["Apache 2.0"],
       links: %{"GitHub" => "https://github.com/team-telnyx/consulex"},
       files: ~w"lib mix.exs README.md LICENSE"
+    ]
+  end
+
+  defp aliases do
+    [
+      test: ["test --no-start"]
     ]
   end
 end

--- a/test/consul/index_store_test.exs
+++ b/test/consul/index_store_test.exs
@@ -1,0 +1,29 @@
+defmodule Consul.IndexStoreTest do
+  use ExUnit.Case
+  alias Consul.IndexStore
+
+  setup do
+    {:ok, _} = start_supervised(IndexStore)
+    :ok
+  end
+
+  test "get index for inexistent key" do
+    key = key()
+    assert IndexStore.get_index(key) |> is_nil()
+  end
+
+  test "store, get and reset index for key" do
+    key = key()
+    IndexStore.store_index(key, "1")
+
+    assert IndexStore.get_index(key) == "1"
+
+    IndexStore.reset_index(key)
+
+    assert IndexStore.get_index(key) |> is_nil()
+  end
+
+  defp key do
+    "http://consul/v1/kv/foo"
+  end
+end

--- a/test/tesla/middleware/consul_watch_test.exs
+++ b/test/tesla/middleware/consul_watch_test.exs
@@ -2,13 +2,14 @@ defmodule Tesla.Middleware.ConsulWatchTest do
   use ExUnit.Case
   import Tesla.Mock
 
-  alias Tesla.Middleware.ConsulWatch
+  alias Consul.IndexStore
 
   @base_url "http://consul"
   @key "foo"
 
   setup do
-    :ok = ConsulWatch.reset(%{url: "#{@base_url}/v1/kv/#{@key}"})
+    {:ok, _} = start_supervised(IndexStore)
+    :ok
   end
 
   test "doesn't specify index on initial fetch" do


### PR DESCRIPTION
Summary:

* extracted index caching from middleware to `Consul.IndexStore` module
* refactored/cleaned up middleware module preserving existing functionality
* added more tests
* added relying on consul's default wait time (which is 5 minutes) when passing `wait: true`
* improved documentation